### PR TITLE
Add notification read state and tests

### DIFF
--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -27,20 +27,23 @@ const customJestConfig = {
 
   // Configure Puppeteer tests to use Node environment
   projects: [
-    {
-      displayName: 'unit',
-      testMatch: [
-        '**/__tests__/**/*.(ts|tsx|js)',
-        '**/*.(test|spec).(ts|tsx|js)',
-        'src/test/**/*.(test|spec).(ts|tsx|js)',
-      ],
-      testEnvironment: 'jsdom',
-      setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
-      moduleNameMapper: {
-        '^@/(.*)$': '<rootDir>/src/$1',
+      {
+        displayName: 'unit',
+        testMatch: [
+          '**/__tests__/**/*.(ts|tsx|js)',
+          '**/*.(test|spec).(ts|tsx|js)',
+          'src/test/**/*.(test|spec).(ts|tsx|js)',
+        ],
+        testEnvironment: 'jsdom',
+        setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
+        moduleNameMapper: {
+          '^@/(.*)$': '<rootDir>/src/$1',
+        },
+        transformIgnorePatterns: ['/node_modules/(?!(jose|@panva/hkdf|openid-client|dexie|uuid|msw))'],
+        transform: {
+          '^.+\\.(js|jsx|ts|tsx)$': ['babel-jest', { presets: ['next/babel'] }],
+        },
       },
-      transformIgnorePatterns: ['/node_modules/(?!(jose|@panva/hkdf|openid-client|dexie|uuid|msw))'],
-    },
     {
       displayName: 'e2e',
       testMatch: ['**/test/proposal-wizard-puppeteer.test.ts'],

--- a/src/components/dashboard/layout/NavigationComponents.tsx
+++ b/src/components/dashboard/layout/NavigationComponents.tsx
@@ -247,7 +247,7 @@ export const NotificationCenter = memo(
       message: string;
       type: 'info' | 'warning' | 'error' | 'success';
       timestamp: string;
-      isRead: boolean;
+      read: boolean;
     }>;
     onNotificationClick: (notificationId: string) => void;
     onMarkAllRead: () => void;
@@ -278,7 +278,7 @@ export const NotificationCenter = memo(
       }
     };
 
-    const unreadCount = notifications.filter(n => !n.isRead).length;
+    const unreadCount = notifications.filter(n => !n.read).length;
 
     return (
       <div className="bg-white rounded-lg shadow-sm border border-gray-200">
@@ -299,7 +299,7 @@ export const NotificationCenter = memo(
                   key={notification.id}
                   onClick={() => onNotificationClick(notification.id)}
                   className={`p-3 border-l-4 cursor-pointer transition-colors ${
-                    notification.isRead
+                    notification.read
                       ? 'border-gray-200 bg-gray-50'
                       : getNotificationColor(notification.type)
                   }`}
@@ -312,7 +312,9 @@ export const NotificationCenter = memo(
                       <div className="text-sm font-medium text-gray-900">{notification.title}</div>
                       <div className="text-sm text-gray-600 mt-1">{notification.message}</div>
                       <div className="text-xs text-gray-500 mt-1">
-                        {new Date(notification.timestamp).toLocaleString('en-US', { timeZone: 'UTC' })}
+                        {new Date(notification.timestamp).toLocaleString('en-US', {
+                          timeZone: 'UTC',
+                        })}
                       </div>
                     </div>
                   </div>

--- a/src/components/dashboard/layout/__tests__/NotificationCenter.test.tsx
+++ b/src/components/dashboard/layout/__tests__/NotificationCenter.test.tsx
@@ -1,0 +1,55 @@
+import { NotificationCenter } from '../NavigationComponents';
+import { render, screen } from '@/test/utils/test-utils';
+import userEvent from '@testing-library/user-event';
+
+describe('NotificationCenter', () => {
+  const baseNotification = {
+    id: '1',
+    title: 'Test',
+    message: 'Message',
+    type: 'info' as const,
+    timestamp: new Date().toISOString(),
+  };
+
+  it('renders mark all read button when there are unread notifications', async () => {
+    const onMarkAllRead = jest.fn();
+    render(
+      <NotificationCenter
+        notifications={[{ ...baseNotification, read: false }]}
+        onNotificationClick={jest.fn()}
+        onMarkAllRead={onMarkAllRead}
+      />
+    );
+
+    const button = screen.getByText('Mark all read');
+    expect(button).toBeInTheDocument();
+    await userEvent.click(button);
+    expect(onMarkAllRead).toHaveBeenCalled();
+  });
+
+  it('does not show mark all read button when all notifications are read', () => {
+    render(
+      <NotificationCenter
+        notifications={[{ ...baseNotification, read: true }]}
+        onNotificationClick={jest.fn()}
+        onMarkAllRead={jest.fn()}
+      />
+    );
+
+    expect(screen.queryByText('Mark all read')).not.toBeInTheDocument();
+  });
+
+  it('calls onNotificationClick when a notification is clicked', async () => {
+    const onNotificationClick = jest.fn();
+    render(
+      <NotificationCenter
+        notifications={[{ ...baseNotification, read: false }]}
+        onNotificationClick={onNotificationClick}
+        onMarkAllRead={jest.fn()}
+      />
+    );
+
+    await userEvent.click(screen.getByText('Test'));
+    expect(onNotificationClick).toHaveBeenCalledWith('1');
+  });
+});

--- a/src/lib/store/__tests__/uiStore.test.ts
+++ b/src/lib/store/__tests__/uiStore.test.ts
@@ -1,0 +1,27 @@
+import { useUIStore } from '../uiStore';
+
+describe('uiStore notifications', () => {
+  beforeEach(() => {
+    const { clearNotifications } = useUIStore.getState();
+    clearNotifications();
+  });
+
+  it('adds notifications with read set to false', () => {
+    const { addNotification } = useUIStore.getState();
+    addNotification({ type: 'info', message: 'Test', persistent: true });
+    const notification = useUIStore.getState().notifications[0];
+    expect(notification.read).toBe(false);
+  });
+
+  it('toggles notification read state', () => {
+    const { addNotification, markNotificationRead } = useUIStore.getState();
+    addNotification({ type: 'info', message: 'Test', persistent: true });
+    const id = useUIStore.getState().notifications[0].id;
+
+    markNotificationRead(id);
+    expect(useUIStore.getState().notifications[0].read).toBe(true);
+
+    markNotificationRead(id);
+    expect(useUIStore.getState().notifications[0].read).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- track read/unread state for notifications in UI store and markNotificationRead toggle
- show read status in NotificationCenter component
- add unit tests for notification state and UI rendering

## Testing
- `npx jest src/lib/store/__tests__/uiStore.test.ts src/components/dashboard/layout/__tests__/NotificationCenter.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68b49f678ef48323b50a7c8899c5a794